### PR TITLE
fixed 'TypeError: error.response is undefined'

### DIFF
--- a/dev-duckies-sm-proj/src/app-wide-components/create-post.jsx
+++ b/dev-duckies-sm-proj/src/app-wide-components/create-post.jsx
@@ -22,7 +22,7 @@ export default function CreatePost(){
 
   useEffect(() => {
     axios.get('http://localhost:8080/profile')
-    .then(res => { setUsername(res.data.profile.username) })
+    .then(res => { setUsername(res.data.username) })
     .catch(error => console.log(error.response.data.error));
 
     //below axios request is a test of updating profile with new profile image


### PR DESCRIPTION
fixed 'TypeError: error.response is undefined' error caused by calling setUsername with 'setUsername(res.data.profile.username)' instead of 'setUsername(res.data.username)'